### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,35 @@
 
 ### Overview
 
-Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the backend is hosted on Convex cloud.
+Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the backend (database, serverless functions, file storage) is hosted on Convex cloud.
 
 ### Services
 
 | Service | Command | Notes |
 |---------|---------|-------|
 | Next.js dev server | `npx next dev` | Serves at http://localhost:3000 |
-| Convex backend | `npx convex dev` | Syncs functions to Convex cloud; requires Convex auth. See `npm run dev` which runs both concurrently. |
+| Convex backend | `npx convex deploy --preview-create <name>` | Pushes functions to a Convex preview deployment. Requires `CONVEX_DEPLOY_KEY`. |
 
-### Running
+### Preview Deployment (backend development)
 
-- `npm run dev` starts both Next.js and Convex dev sync via `concurrently`.
-- If you only need the frontend (e.g. the Convex cloud backend at the URL in `.env` is already deployed), run `npx next dev` alone.
-- The `.env` file contains `NEXT_PUBLIC_CONVEX_URL` pointing to the deployed Convex backend.
+The update script automatically creates a Convex preview deployment on startup when `CONVEX_DEPLOY_KEY` is set. It:
+1. Runs `npx convex deploy --preview-create <branch-name>` to push functions and create/update the preview
+2. Writes the preview URL to `.env.local` (overriding the production URL in `.env`)
+3. Sets `SSR_KEY=cloud-agent-ssr-key` on the preview deployment and locally
+
+After modifying any files in `convex/`, re-deploy with:
+```
+PREVIEW_NAME=$(git branch --show-current | tr '/' '-')
+npx convex deploy --preview-create "${PREVIEW_NAME:-cloud-agent}"
+```
+
+### Running the frontend
+
+```
+npx next dev
+```
+
+Next.js reads `NEXT_PUBLIC_CONVEX_URL` from `.env.local` (or `.env` as fallback).
 
 ### Lint / Test / Build
 
@@ -25,6 +40,7 @@ Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the
 
 ### Caveats
 
-- `npm ci` may fail if `package-lock.json` is out of sync with `package.json`. Use `npm install` to regenerate it first.
+- `npm ci` may fail if `package-lock.json` is out of sync with `package.json`. The update script uses `npm install` instead.
 - Watchpack permission warnings (e.g. `/etc/credstore`, `/root/.ssh`) in Next.js dev output are harmless and can be ignored.
-- `convex dev` requires Convex CLI authentication. Without it, the frontend still works if `NEXT_PUBLIC_CONVEX_URL` points to an already-deployed backend.
+- `SSR_KEY` must match between the Next.js server env and the Convex deployment env. The update script sets both to `cloud-agent-ssr-key`. Without `SSR_KEY`, the `/display` page (viewing a whisper) will error.
+- The `/display` page uses SSR (`getServerSideProps`) to call `accessWhisper` with the `SSR_KEY`, so it only works when `SSR_KEY` is correctly configured on both sides.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,30 @@
 ## Cloud-specific instructions
 
+### Required secrets
+
+- `CONVEX_DEPLOY_KEY` — Convex Preview Deploy Key. Generate from the Convex dashboard: Project → Settings → Deploy Keys → Preview Deploy Key.
+
 ### Overview
 
 Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the backend (database, serverless functions, file storage) is hosted on Convex cloud.
 
 ### Services
 
-| Service | Command | Notes |
-|---------|---------|-------|
-| Next.js dev server | `npx next dev` | Serves at http://localhost:3000 |
-| Convex backend | `npx convex deploy --preview-create <name>` | Pushes functions to a Convex preview deployment. Requires `CONVEX_DEPLOY_KEY`. |
+| Service            | Command                                     | Notes                                                                          |
+| ------------------ | ------------------------------------------- | ------------------------------------------------------------------------------ |
+| Next.js dev server | `npx next dev`                              | Serves at http://localhost:3000                                                |
+| Convex backend     | `npx convex deploy --preview-create <name>` | Pushes functions to a Convex preview deployment. Requires `CONVEX_DEPLOY_KEY`. |
 
 ### Preview Deployment (backend development)
 
 The update script automatically creates a Convex preview deployment on startup when `CONVEX_DEPLOY_KEY` is set. It:
+
 1. Runs `npx convex deploy --preview-create <branch-name>` to push functions and create/update the preview
 2. Writes the preview URL to `.env.local` (overriding the production URL in `.env`)
 3. Sets `SSR_KEY=cloud-agent-ssr-key` on the preview deployment and locally
 
 After modifying any files in `convex/`, re-deploy with:
+
 ```
 PREVIEW_NAME=$(git branch --show-current | tr '/' '-')
 npx convex deploy --preview-create "${PREVIEW_NAME:-cloud-agent}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+## Cloud-specific instructions
+
+### Overview
+
+Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the backend is hosted on Convex cloud.
+
+### Services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| Next.js dev server | `npx next dev` | Serves at http://localhost:3000 |
+| Convex backend | `npx convex dev` | Syncs functions to Convex cloud; requires Convex auth. See `npm run dev` which runs both concurrently. |
+
+### Running
+
+- `npm run dev` starts both Next.js and Convex dev sync via `concurrently`.
+- If you only need the frontend (e.g. the Convex cloud backend at the URL in `.env` is already deployed), run `npx next dev` alone.
+- The `.env` file contains `NEXT_PUBLIC_CONVEX_URL` pointing to the deployed Convex backend.
+
+### Lint / Test / Build
+
+- **Lint**: `npm run lint` (ESLint + Prettier)
+- **Test**: `npm test` (Vitest with `convex-test`; tests run in-memory, no Convex backend needed)
+- **Build**: `npm run build`
+
+### Caveats
+
+- `npm ci` may fail if `package-lock.json` is out of sync with `package.json`. Use `npm install` to regenerate it first.
+- Watchpack permission warnings (e.g. `/etc/credstore`, `/root/.ssh`) in Next.js dev output are harmless and can be ignored.
+- `convex dev` requires Convex CLI authentication. Without it, the frontend still works if `NEXT_PUBLIC_CONVEX_URL` points to an already-deployed backend.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,12 @@ Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the
 
 The update script automatically creates a Convex preview deployment on startup when `CONVEX_DEPLOY_KEY` is set. It:
 
-1. Runs `npx convex deploy --preview-create <branch-name>` to push functions and create/update the preview
-2. Writes the preview URL to `.env.local` (overriding the production URL in `.env`)
-3. Sets `SSR_KEY=cloud-agent-ssr-key` on the preview deployment and locally
+1. Derives a preview name from the current git branch
+2. Runs `npx convex deploy --preview-create <name>` with `--cmd` to write the preview URL into `.env.local`
+3. Pushes Convex functions to the preview deployment
+4. Sets `SSR_KEY=cloud-agent-ssr-key` on the preview deployment via `npx convex env set`
+
+The `--cmd` / `--cmd-url-env-var-name` flags are the Convex-provided mechanism for passing the deployment URL to a command (see `npx convex deploy --help`). The update script uses them to write `.env.local` instead of the typical `npm run build`.
 
 After modifying any files in `convex/`, re-deploy with:
 


### PR DESCRIPTION
Set up Convex preview deployments to enable full backend development for cloud agents.

This PR enables cloud agents to develop the Convex backend by automatically creating a preview deployment on startup when `CONVEX_DEPLOY_KEY` is provided. The `convex deploy --preview-create` command is used with `--cmd` to write the generated `NEXT_PUBLIC_CONVEX_URL` and `SSR_KEY` into `.env.local`, as `convex deploy` does not automatically update environment files. `AGENTS.md` is updated to document this workflow and the required secret.

---
<p><a href="https://cursor.com/agents?id=bc-49be2461-433c-44e4-b585-9a9cfbb80c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49be2461-433c-44e4-b585-9a9cfbb80c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

