### PR TITLE
Whispers multiple attachments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,10 @@ Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the
 
 ### Services
 
-| Service            | Command                                     | Notes                                                                          |
-| ------------------ | ------------------------------------------- | ------------------------------------------------------------------------------ |
-| Next.js dev server | `npx next dev`                              | Serves at http://localhost:3000                                                |
-| Convex backend     | `npx convex deploy --preview-name <name>`  | Pushes functions to an existing preview deployment. Requires `CONVEX_DEPLOY_KEY`. |
+| Service            | Command                                   | Notes                                                                             |
+| ------------------ | ----------------------------------------- | --------------------------------------------------------------------------------- |
+| Next.js dev server | `npx next dev`                            | Serves at http://localhost:3000                                                   |
+| Convex backend     | `npx convex deploy --preview-name <name>` | Pushes functions to an existing preview deployment. Requires `CONVEX_DEPLOY_KEY`. |
 
 ### Preview Deployment (backend development)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ PREVIEW_NAME=$(git branch --show-current | tr '/' '-')
 npx convex deploy --preview-create "${PREVIEW_NAME:-cloud-agent}"
 ```
 
+This is a required step for cloud agents: if you changed anything under `convex/`, do not finish the task until this deploy command succeeds.
+
 ### Running the frontend
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the
 | Service            | Command                                     | Notes                                                                          |
 | ------------------ | ------------------------------------------- | ------------------------------------------------------------------------------ |
 | Next.js dev server | `npx next dev`                              | Serves at http://localhost:3000                                                |
-| Convex backend     | `npx convex deploy --preview-create <name>` | Pushes functions to a Convex preview deployment. Requires `CONVEX_DEPLOY_KEY`. |
+| Convex backend     | `npx convex deploy`                         | Pushes functions to the existing deployment selected by env vars/keys. Requires `CONVEX_DEPLOY_KEY` for preview deploys. |
 
 ### Preview Deployment (backend development)
 
@@ -26,12 +26,13 @@ The update script automatically creates a Convex preview deployment on startup w
 
 The `--cmd` / `--cmd-url-env-var-name` flags are the Convex-provided mechanism for passing the deployment URL to a command (see `npx convex deploy --help`). The update script uses them to write `.env.local` instead of the typical `npm run build`.
 
-After modifying any files in `convex/`, re-deploy with:
+After modifying any files in `convex/`, push updates to the existing preview deployment with:
 
 ```
-PREVIEW_NAME=$(git branch --show-current | tr '/' '-')
-npx convex deploy --preview-create "${PREVIEW_NAME:-cloud-agent}"
+npx convex deploy
 ```
+
+Use `--preview-create` only when initially creating a preview deployment. Do not use it for follow-up deploys from the same branch.
 
 This is a required step for cloud agents: if you changed anything under `convex/`, do not finish the task until this deploy command succeeds.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Whisper is a Next.js + Convex secret-sharing app. The frontend runs locally; the
 | Service            | Command                                     | Notes                                                                          |
 | ------------------ | ------------------------------------------- | ------------------------------------------------------------------------------ |
 | Next.js dev server | `npx next dev`                              | Serves at http://localhost:3000                                                |
-| Convex backend     | `npx convex deploy`                         | Pushes functions to the existing deployment selected by env vars/keys. Requires `CONVEX_DEPLOY_KEY` for preview deploys. |
+| Convex backend     | `npx convex deploy --preview-name <name>`  | Pushes functions to an existing preview deployment. Requires `CONVEX_DEPLOY_KEY`. |
 
 ### Preview Deployment (backend development)
 
@@ -29,10 +29,11 @@ The `--cmd` / `--cmd-url-env-var-name` flags are the Convex-provided mechanism f
 After modifying any files in `convex/`, push updates to the existing preview deployment with:
 
 ```
-npx convex deploy
+PREVIEW_NAME=$(git branch --show-current | tr '/' '-')
+npx convex deploy --preview-name "${PREVIEW_NAME:-cloud-agent}"
 ```
 
-Use `--preview-create` only when initially creating a preview deployment. Do not use it for follow-up deploys from the same branch.
+Use `--preview-create` only when initially creating a preview deployment. For follow-up deploys from the same branch, use `--preview-name`.
 
 This is a required step for cloud agents: if you changed anything under `convex/`, do not finish the task until this deploy command succeeds.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,14 @@ Next.js reads `NEXT_PUBLIC_CONVEX_URL` from `.env.local` (or `.env` as fallback)
 - **Test**: `npm test` (Vitest with `convex-test`; tests run in-memory, no Convex backend needed)
 - **Build**: `npm run build`
 
+### Manual smoke test flow
+
+When validating the share flow manually in the browser:
+
+1. Create a secret and click **Create Whisper**.
+2. Click **Copy to Clipboard** on the created page.
+3. Paste the copied URL into the browser address bar and navigate to it. Do not type the URL manually.
+
 ### Caveats
 
 - `npm ci` may fail if `package-lock.json` is out of sync with `package.json`. The update script uses `npm install` instead.

--- a/common.test.ts
+++ b/common.test.ts
@@ -1,0 +1,80 @@
+import CryptoJS from 'crypto-js';
+import { test, expect, vi, beforeEach } from 'vitest';
+
+const { mockUuid } = vi.hoisted(() => ({
+  mockUuid: vi.fn(),
+}));
+
+vi.mock('uuid', () => ({
+  v4: mockUuid,
+}));
+
+import { createWhisper } from './common';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  mockUuid.mockReset();
+});
+
+test('createWhisper uploads all selected files', async () => {
+  mockUuid
+    .mockReturnValueOnce('whisper-name')
+    .mockReturnValueOnce('creator-key');
+
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ storageId: 'storage-1' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ storageId: 'storage-2' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+  vi.stubGlobal('fetch', fetchMock);
+
+  const makeUploadURLMock = vi
+    .fn()
+    .mockResolvedValueOnce('https://upload-url-1')
+    .mockResolvedValueOnce('https://upload-url-2');
+  const createWhisperMutationMock = vi.fn().mockResolvedValue(undefined);
+
+  const response = await createWhisper(
+    'top secret',
+    [
+      new File(['alpha'], 'alpha.txt', { type: 'text/plain' }),
+      new File(['beta'], 'beta.txt', { type: 'text/plain' }),
+    ],
+    'after one access',
+    'known-password',
+    createWhisperMutationMock as Parameters<typeof createWhisper>[4],
+    makeUploadURLMock as Parameters<typeof createWhisper>[5],
+    false
+  );
+
+  expect(response).toEqual({
+    name: 'whisper-name',
+    creatorKey: 'creator-key',
+    password: 'known-password',
+  });
+  expect(makeUploadURLMock).toHaveBeenCalledTimes(2);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+
+  const createPayload = createWhisperMutationMock.mock.calls[0][0];
+  expect(createPayload.storageIds).toEqual(['storage-1', 'storage-2']);
+
+  const decryptedSecret = CryptoJS.AES.decrypt(
+    createPayload.encryptedSecret,
+    'known-password'
+  ).toString(CryptoJS.enc.Utf8);
+
+  const alphaHex = Buffer.from('alpha.txt', 'ascii').toString('hex');
+  const betaHex = Buffer.from('beta.txt', 'ascii').toString('hex');
+  expect(decryptedSecret).toContain(`Attachment: '${alphaHex}' storage-1`);
+  expect(decryptedSecret).toContain(`Attachment: '${betaHex}' storage-2`);
+});

--- a/common.ts
+++ b/common.ts
@@ -21,7 +21,7 @@ const encryptFile = async (blob: Blob, password: string): Promise<Blob> => {
 
 export async function createWhisper(
   secret: string,
-  selectedFile: File | null,
+  selectedFiles: File[],
   expiration: string,
   password: string,
   createWhisperMutation: ReactMutation<typeof api.createWhisper.default>,
@@ -33,8 +33,8 @@ export async function createWhisper(
   if (password.length === 0) {
     password = uuidv4();
   }
-  const storageIds = [];
-  if (selectedFile) {
+  const storageIds: string[] = [];
+  for (const selectedFile of selectedFiles) {
     const [uploadURL, encryptedFile] = await Promise.all([
       makeUploadURL(),
       encryptFile(selectedFile, password),
@@ -44,11 +44,11 @@ export async function createWhisper(
       headers: { 'Content-Type': 'application/octet-stream' },
       body: encryptedFile,
     });
-    const resultJson = await result.json();
-    if (!result.ok) {
-      console.error(resultJson);
+    const resultJson: { storageId?: string } = await result.json();
+    if (!result.ok || typeof resultJson.storageId !== 'string') {
+      throw new Error(`upload failed for file ${selectedFile.name}`);
     }
-    const storageId = resultJson['storageId'];
+    const storageId = resultJson.storageId;
     storageIds.push(storageId);
     const name = Buffer.from(selectedFile.name, 'ascii').toString('hex');
     secret += `\nAttachment: '${name}' ${storageId}`;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next';
 import styles from '../styles/Home.module.css';
 import { useMutation } from 'convex/react';
-import { useState } from 'react';
+import { useState, type ChangeEvent } from 'react';
 import { createWhisper } from '../common';
 import { expirationOptions } from '../expiration';
 import { useRouter } from 'next/router';
@@ -15,12 +15,26 @@ const Home: NextPage = () => {
   const [password, setPassword] = useState('');
   const [requestGeolocation, setRequestGeolocation] = useState(false);
   const router = useRouter();
-  const [selectedFile, setSelectedFile] = useState<null | File>(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const makeUploadURL = useMutation(api.fileUploadURL.default);
+  const onAttachFile = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    if (files.length === 0) {
+      return;
+    }
+    setSelectedFiles((previousFiles) => previousFiles.concat(files));
+    // Let users pick the same file again if they removed it.
+    event.target.value = '';
+  };
+  const removeFileAtIndex = (indexToRemove: number) => {
+    setSelectedFiles((previousFiles) =>
+      previousFiles.filter((_, index) => index !== indexToRemove)
+    );
+  };
   const create = async () => {
     const createResponse = await createWhisper(
       secret,
-      selectedFile,
+      selectedFiles,
       expiration,
       password,
       createWhisperMutation,
@@ -44,8 +58,23 @@ const Home: NextPage = () => {
         attach secret file{' '}
         <input
           type="file"
-          onChange={(event) => setSelectedFile(event.target.files![0])}
+          multiple
+          onChange={onAttachFile}
         />
+        {selectedFiles.length > 0 && (
+          <ul>
+            {selectedFiles.map((selectedFile, index) => (
+              <li
+                key={`${selectedFile.name}-${selectedFile.lastModified}-${index}`}
+              >
+                {selectedFile.name}{' '}
+                <button type="button" onClick={() => removeFileAtIndex(index)}>
+                  remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
       <div>
         <span>expires&nbsp;</span>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -56,11 +56,7 @@ const Home: NextPage = () => {
       />
       <div>
         attach secret file{' '}
-        <input
-          type="file"
-          multiple
-          onChange={onAttachFile}
-        />
+        <input type="file" multiple onChange={onAttachFile} />
         {selectedFiles.length > 0 && (
           <ul>
             {selectedFiles.map((selectedFile, index) => (


### PR DESCRIPTION
Enable attaching multiple files to a whisper sequentially and update `AGENTS.md` with development guidelines.

Previously, the system only supported a single file attachment, with each new selection replacing the prior one. This change allows users to accumulate multiple files before sending a whisper.

---
<p><a href="https://cursor.com/agents?id=bc-e5c40923-756a-4f84-adc0-9254c20c9c5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5c40923-756a-4f84-adc0-9254c20c9c5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

