### PR TITLE
Sender name support

### DIFF
--- a/common.ts
+++ b/common.ts
@@ -21,6 +21,7 @@ const encryptFile = async (blob: Blob, password: string): Promise<Blob> => {
 
 export async function createWhisper(
   secret: string,
+  sender: string,
   selectedFile: File | null,
   expiration: string,
   password: string,
@@ -54,10 +55,12 @@ export async function createWhisper(
     secret += `\nAttachment: '${name}' ${storageId}`;
   }
   const encryptedSecret = CryptoJS.AES.encrypt(secret, password).toString();
+  const encryptedSender = CryptoJS.AES.encrypt(sender.trim(), password).toString();
   const passwordHash = hashPassword(password);
   await createWhisperMutation({
     whisperName: name,
     encryptedSecret,
+    encryptedSender,
     storageIds,
     passwordHash,
     creatorKey,

--- a/common.ts
+++ b/common.ts
@@ -55,7 +55,10 @@ export async function createWhisper(
     secret += `\nAttachment: '${name}' ${storageId}`;
   }
   const encryptedSecret = CryptoJS.AES.encrypt(secret, password).toString();
-  const encryptedSender = CryptoJS.AES.encrypt(sender.trim(), password).toString();
+  const encryptedSender = CryptoJS.AES.encrypt(
+    sender.trim(),
+    password
+  ).toString();
   const passwordHash = hashPassword(password);
   await createWhisperMutation({
     whisperName: name,

--- a/convex/createWhisper.ts
+++ b/convex/createWhisper.ts
@@ -6,6 +6,7 @@ export default mutation({
   args: {
     whisperName: v.string(),
     encryptedSecret: v.string(),
+    encryptedSender: v.string(),
     storageIds: v.array(v.string()),
     passwordHash: v.string(),
     creatorKey: v.string(),
@@ -17,6 +18,7 @@ export default mutation({
     {
       whisperName,
       encryptedSecret,
+      encryptedSender,
       storageIds,
       passwordHash,
       creatorKey,
@@ -34,6 +36,7 @@ export default mutation({
     await db.insert('whispers', {
       name: whisperName,
       encryptedSecret,
+      encryptedSender,
       storageIds,
       passwordHash,
       creatorKey,

--- a/convex/readSecret.ts
+++ b/convex/readSecret.ts
@@ -11,6 +11,7 @@ export default query({
   },
   returns: v.object({
     encryptedSecret: v.string(),
+    encryptedSender: v.union(v.string(), v.null()),
     storageURLs: v.record(v.string(), v.union(v.string(), v.null())),
   }),
   handler: async (
@@ -39,6 +40,7 @@ export default query({
     );
     return {
       encryptedSecret: whisperDoc.encryptedSecret,
+      encryptedSender: whisperDoc.encryptedSender ?? null,
       storageURLs: Object.fromEntries(storageURLs),
     };
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,6 +6,8 @@ export default defineSchema({
     name: v.string(),
     // Encrypted with password.
     encryptedSecret: v.string(),
+    // Encrypted with password.
+    encryptedSender: v.optional(v.string()),
     // Each stored file is encrypted with password.
     storageIds: v.optional(v.array(v.string())),
     // So recipient can prove to server (in accessWhisper) that they are allowed

--- a/pages/access.tsx
+++ b/pages/access.tsx
@@ -41,7 +41,7 @@ const AccessButton = ({
   const router = useRouter();
   return (
     <>
-      A secret was shared with you
+      Someone whispered a secret to you
       <button
         className={styles.button}
         onClick={() => {

--- a/pages/access.tsx
+++ b/pages/access.tsx
@@ -41,7 +41,7 @@ const AccessButton = ({
   const router = useRouter();
   return (
     <>
-      Someone whispered a secret to you
+      A secret was shared with you
       <button
         className={styles.button}
         onClick={() => {

--- a/pages/display.tsx
+++ b/pages/display.tsx
@@ -73,12 +73,14 @@ const SecretDisplay = ({
   accessKey: string;
   password: string;
 }) => {
-  const { encryptedSecret, encryptedSender, storageURLs } =
-    useQuery(api.readSecret.default, {
+  const { encryptedSecret, encryptedSender, storageURLs } = useQuery(
+    api.readSecret.default,
+    {
       whisperName: name,
       accessKey,
       passwordHash: hashPassword(password),
-    }) ?? { encryptedSecret: undefined, encryptedSender: null, storageURLs: {} };
+    }
+  ) ?? { encryptedSecret: undefined, encryptedSender: null, storageURLs: {} };
   if (!encryptedSecret) {
     return (
       <div className={styles.secretDisplay + ' ' + styles.secretOutput}>
@@ -91,7 +93,8 @@ const SecretDisplay = ({
         .toString(CryptoJS.enc.Utf8)
         .trim()
     : '';
-  const senderDisplay = decryptedSender.length > 0 ? decryptedSender : 'Someone';
+  const senderDisplay =
+    decryptedSender.length > 0 ? decryptedSender : 'Someone';
   let decryptedSecret: string = CryptoJS.AES.decrypt(
     encryptedSecret,
     password
@@ -120,7 +123,9 @@ const SecretDisplay = ({
   }
   return (
     <>
-      <div className={styles.description}>{`${senderDisplay} sent you a secret`}</div>
+      <div
+        className={styles.description}
+      >{`${senderDisplay} sent you a secret`}</div>
       <div className={styles.secretDisplay + ' ' + styles.secretOutput}>
         {decryptedSecret}
         {attachments}

--- a/pages/display.tsx
+++ b/pages/display.tsx
@@ -73,11 +73,12 @@ const SecretDisplay = ({
   accessKey: string;
   password: string;
 }) => {
-  const { encryptedSecret, storageURLs } = useQuery(api.readSecret.default, {
-    whisperName: name,
-    accessKey,
-    passwordHash: hashPassword(password),
-  }) ?? { encryptedSecret: undefined, storageURLs: [] };
+  const { encryptedSecret, encryptedSender, storageURLs } =
+    useQuery(api.readSecret.default, {
+      whisperName: name,
+      accessKey,
+      passwordHash: hashPassword(password),
+    }) ?? { encryptedSecret: undefined, encryptedSender: null, storageURLs: {} };
   if (!encryptedSecret) {
     return (
       <div className={styles.secretDisplay + ' ' + styles.secretOutput}>
@@ -85,6 +86,12 @@ const SecretDisplay = ({
       </div>
     );
   }
+  const decryptedSender = encryptedSender
+    ? CryptoJS.AES.decrypt(encryptedSender, password)
+        .toString(CryptoJS.enc.Utf8)
+        .trim()
+    : '';
+  const senderDisplay = decryptedSender.length > 0 ? decryptedSender : 'Someone';
   let decryptedSecret: string = CryptoJS.AES.decrypt(
     encryptedSecret,
     password
@@ -112,10 +119,13 @@ const SecretDisplay = ({
     }
   }
   return (
-    <div className={styles.secretDisplay + ' ' + styles.secretOutput}>
-      {decryptedSecret}
-      {attachments}
-    </div>
+    <>
+      <div className={styles.description}>{`${senderDisplay} sent you a secret`}</div>
+      <div className={styles.secretDisplay + ' ' + styles.secretOutput}>
+        {decryptedSecret}
+        {attachments}
+      </div>
+    </>
   );
 };
 
@@ -303,7 +313,6 @@ const DisplayPage: NextPage<DisplayPageProps> = ({
       whisperName={name}
       passwordHash={hashPassword(password)}
     >
-      Someone whispered this secret to you
       <SecretDisplay name={name} accessKey={accessKey} password={password} />
     </ExpirationWrapper>
   );

--- a/pages/display.tsx
+++ b/pages/display.tsx
@@ -125,7 +125,7 @@ const SecretDisplay = ({
     <>
       <div
         className={styles.description}
-      >{`${senderDisplay} sent you a secret`}</div>
+      >{`${senderDisplay} whispered this secret to you`}</div>
       <div className={styles.secretDisplay + ' ' + styles.secretOutput}>
         {decryptedSecret}
         {attachments}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,7 @@ import { api } from '../convex/_generated/api';
 const Home: NextPage = () => {
   const createWhisperMutation = useMutation(api.createWhisper.default);
   const [secret, setSecret] = useState('');
+  const [sender, setSender] = useState('');
   const [expiration, setExpiration] = useState(expirationOptions[0]);
   const [password, setPassword] = useState('');
   const [requestGeolocation, setRequestGeolocation] = useState(false);
@@ -20,6 +21,7 @@ const Home: NextPage = () => {
   const create = async () => {
     const createResponse = await createWhisper(
       secret,
+      sender,
       selectedFile,
       expiration,
       password,
@@ -40,6 +42,16 @@ const Home: NextPage = () => {
         value={secret}
         onChange={(e) => setSecret(e.target.value)}
       />
+      <div>
+        sender{' '}
+        <input
+          type="text"
+          className={styles.passwordInput}
+          placeholder="your name (optional)"
+          value={sender}
+          onChange={(e) => setSender(e.target.value)}
+        />
+      </div>
       <div>
         attach secret file{' '}
         <input

--- a/whisper.test.ts
+++ b/whisper.test.ts
@@ -14,6 +14,7 @@ test('full whisper flow', async () => {
   // Test data
   const whisperName = 'test-whisper';
   const encryptedSecret = 'encrypted-data';
+  const encryptedSender = 'encrypted-sender';
   const passwordHash = 'hashed-password';
   const creatorKey = 'creator123';
   const accessKey = 'access123';
@@ -23,6 +24,7 @@ test('full whisper flow', async () => {
   await t.mutation(api.createWhisper.default, {
     whisperName,
     encryptedSecret,
+    encryptedSender,
     storageIds: [],
     passwordHash,
     creatorKey,
@@ -47,5 +49,6 @@ test('full whisper flow', async () => {
   });
 
   expect(result.encryptedSecret).toBe(encryptedSecret);
+  expect(result.encryptedSender).toBe(encryptedSender);
   expect(result.storageURLs).toEqual({});
 });


### PR DESCRIPTION
Adds an end-to-end encrypted 'sender' field to secrets, allowing the recipient to see who sent the secret.

---
<p><a href="https://cursor.com/agents/bc-eadf00d2-0f17-4d38-a5a9-bb0a3fefe332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eadf00d2-0f17-4d38-a5a9-bb0a3fefe332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

